### PR TITLE
Migrate to https

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,10 @@
 title:            Slate+Simple Jekyll Theme
 description:      Your site description...
 copyright:        Your Name
-       
+url: # add your custom site url (format: https://example.com)
 
-future:      false  # publish future dated posts --  true, false (default) 
+
+future:      false  # publish future dated posts --  true, false (default)
 highlighter: rouge
 markdown:    kramdown
 gems:
@@ -11,7 +12,7 @@ gems:
   - jekyll-paginate
   - jekyll-gist
   - jekyll-feed
-  
+
 sass:
   sass_dir: _sass
   style: compressed
@@ -29,10 +30,10 @@ paginate: 5
 #  toc_levels: 1..6
 #  enable_coderay: false
 
-include: 
+include:
   - .htaccess
-  
-exclude: 
+
+exclude:
   - "*.less"
   - "*.sublime-project"
   - "*.sublime-workspace"

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,3 +1,3 @@
 <span>
-    &copy; {{ site.time | date: '%Y' }} {{ site.copyright }}.<br>Powered by <a target="_blank" href="http://jekyllrb.com" rel="nofollow">Jekyll</a> using the <a target="_blank" href="https://github.com/benradford/Slate-and-Simple-Jekyll-Theme">Slate+Simple</a> theme.
+    &copy; {{ site.time | date: '%Y' }} {{ site.copyright }}.<br>Powered by <a target="_blank" href="https://jekyllrb.com" rel="nofollow">Jekyll</a> using the <a target="_blank" href="https://github.com/benradford/Slate-and-Simple-Jekyll-Theme">Slate+Simple</a> theme.
 </span>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,7 +4,7 @@
 {% if page.tags %}<meta name="keywords" content="{{ page.tags | join: ', ' }}">{% endif %}
 
 <!-- MathJax -->
-<script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
+<script type="text/javascript" async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML"></script>
 
 {% if site.owner.twitter %}<!-- Twitter Cards -->
 {% if page.image.feature %}<meta name="twitter:card" content="summary_large_image">
@@ -56,10 +56,6 @@
 
 <style type="text/css">body {background-image:url({{ background }});}</style>
 {% endif %}
-
-<script type="text/javascript"
-    src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
-</script>
 
 <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
 

--- a/about/index.md
+++ b/about/index.md
@@ -3,11 +3,11 @@ layout: post
 title: About
 ---
 <p>
-This theme is available for free under the MIT open source software license. 
+This theme is available for free under the MIT open source software license.
 <br>
 The theme can be found <a href="https://github.com/benradford/Slate-and-Simple-Jekyll-Theme">here</a>.
 <br>
-The theme requires <a href="http://jekyllrb.com">Jekyll</a>, a static-site generator compatible with <a href="https://pages.github.com">pages.github.com</a>.
+The theme requires <a href="https://jekyllrb.com">Jekyll</a>, a static-site generator compatible with <a href="https://pages.github.com">pages.github.com</a>.
 </p>
 
 <hr>


### PR DESCRIPTION
This may be Minor but important pull request I guess.

I've been struggling with https problem for about 2 days. Github pages won't apply https my page using this theme. The problem was there were legacy http links remaining. 

So I changed every http in source file to https and now it works fine. Plus, for those who use the theme under custom url, I've added jekyll **url** settings in config file. And of course prettify whitespaces from my Sublime editor settings.

Hope this helps. 